### PR TITLE
Specify config file in docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker pull calpa/urusai:latest
 docker run calpa/urusai
 
 # ⚙️ Run with custom configuration (mount your config file)
-docker run -v $(pwd)/config.json:/app/config.json calpa/urusai
+docker run -v $(pwd)/config.json:/app/config.json calpa/urusai --config config.json
 ```
 
 The Docker image is available for multiple platforms:


### PR DESCRIPTION
I have added `--config` param to specify a custom config in Docker CLI. If it is not specified, Urusai uses the default configuration. The custom config we pass is ignored.