### PR TITLE
feat: add concurrent crawling with context support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,20 @@ type Config struct {
 	MinSleep        int      `json:"min_sleep"`
 	MaxSleep        int      `json:"max_sleep"`
 	Timeout         int      `json:"timeout"`
+	Concurrency     int      `json:"concurrency"`
 	RootURLs        []string `json:"root_urls"`
 	BlacklistedURLs []string `json:"blacklisted_urls"`
 	UserAgents      []string `json:"user_agents"`
+}
+
+// Validate checks configuration values and applies defaults.
+func (c *Config) Validate() {
+	if c.Concurrency <= 0 {
+		c.Concurrency = 1
+	}
+	if c.Timeout < 0 {
+		c.Timeout = 0
+	}
 }
 
 // LoadFromFile loads configuration from a JSON file
@@ -35,11 +46,7 @@ func LoadFromFile(filePath string) (*Config, error) {
 		return nil, err
 	}
 
-	// Convert timeout=false to 0 (no timeout)
-	if config.Timeout < 0 {
-		config.Timeout = 0
-	}
-
+	config.Validate()
 	return config, nil
 }
 
@@ -56,5 +63,6 @@ func LoadDefaultConfig() (*Config, error) {
 		return nil, err
 	}
 
+	config.Validate()
 	return config, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,7 +10,6 @@ func TestLoadDefaultConfig(t *testing.T) {
 		t.Fatalf("Failed to load default config: %v", err)
 	}
 
-	// Verify that the default config has valid values
 	if cfg.MaxDepth <= 0 {
 		t.Errorf("Expected MaxDepth > 0, got %d", cfg.MaxDepth)
 	}
@@ -29,5 +28,41 @@ func TestLoadDefaultConfig(t *testing.T) {
 
 	if len(cfg.UserAgents) == 0 {
 		t.Error("Expected UserAgents to have at least one user agent")
+	}
+
+	if cfg.Concurrency != 3 {
+		t.Errorf("Expected default Concurrency=3, got %d", cfg.Concurrency)
+	}
+}
+
+func TestValidateConcurrency(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected int
+	}{
+		{"zero defaults to 1", 0, 1},
+		{"negative defaults to 1", -5, 1},
+		{"positive preserved", 4, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Concurrency: tt.input}
+			c.Validate()
+			if c.Concurrency != tt.expected {
+				t.Errorf("Validate(): Concurrency=%d, want %d", c.Concurrency, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateTimeout(t *testing.T) {
+	c := &Config{Timeout: -1, Concurrency: 2}
+	c.Validate()
+	if c.Timeout != 0 {
+		t.Errorf("Validate(): Timeout=%d, want 0", c.Timeout)
+	}
+	if c.Concurrency != 2 {
+		t.Errorf("Validate(): Concurrency=%d, want 2", c.Concurrency)
 	}
 }

--- a/config/default_config.json
+++ b/config/default_config.json
@@ -3,6 +3,7 @@
     "min_sleep": 3,
     "max_sleep": 6,
     "timeout": 0,
+    "concurrency": 3,
     "root_urls": [
         "https://www.wikipedia.org",
         "https://www.github.com",

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -1,12 +1,14 @@
 package crawler
 
 import (
+	"context"
 	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/calpa/urusai/config"
@@ -15,6 +17,7 @@ import (
 // Crawler represents a web crawler that generates random HTTP traffic
 type Crawler struct {
 	config     *config.Config
+	mu         sync.Mutex
 	links      []string
 	startTime  time.Time
 	httpClient *http.Client
@@ -31,53 +34,69 @@ func NewCrawler(cfg *config.Config) *Crawler {
 	}
 }
 
-// Crawl starts the crawling process
-func (c *Crawler) Crawl() {
+// Crawl starts the crawling process with concurrent workers.
+func (c *Crawler) Crawl(ctx context.Context) {
 	c.startTime = time.Now()
 
+	var wg sync.WaitGroup
+	for i := 0; i < c.config.Concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.worker(ctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// worker independently picks random root URLs and follows links until ctx is cancelled or timeout is reached.
+func (c *Crawler) worker(ctx context.Context) {
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		if c.isTimeoutReached() {
 			log.Println("Timeout has been reached, exiting")
 			return
 		}
 
-		// Select a random root URL
+		c.mu.Lock()
 		rootURL := c.config.RootURLs[rand.Intn(len(c.config.RootURLs))]
+		c.mu.Unlock()
 		log.Printf("Starting with root URL: %s", rootURL)
 
-		try := func() bool {
-			body, err := c.request(rootURL)
-			if err != nil {
-				log.Printf("Error connecting to root URL %s: %v", rootURL, err)
-				return false
-			}
-
-			c.links = c.extractURLs(body, rootURL)
-			log.Printf("Found %d links from %s", len(c.links), rootURL)
-
-			if len(c.links) > 0 {
-				c.browseFromLinks(0)
-				return true
-			}
-			return false
+		body, err := c.request(ctx, rootURL)
+		if err != nil {
+			log.Printf("Error connecting to root URL %s: %v", rootURL, err)
+			continue
 		}
 
-		// Try to crawl, if failed, try another root URL
-		if !try() {
-			continue
+		c.mu.Lock()
+		c.links = c.extractURLs(body, rootURL)
+		linkCount := len(c.links)
+		c.mu.Unlock()
+
+		log.Printf("Found %d links from %s", linkCount, rootURL)
+
+		if linkCount > 0 {
+			c.browseFromLinks(ctx, 0)
 		}
 	}
 }
 
-// request sends an HTTP request to the given URL with a random user agent
-func (c *Crawler) request(urlStr string) (string, error) {
-	req, err := http.NewRequest("GET", urlStr, nil)
+// request sends an HTTP request to the given URL with a random user agent.
+func (c *Crawler) request(ctx context.Context, urlStr string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
 	if err != nil {
 		return "", err
 	}
 
-	// Set a random user agent
+	c.mu.Lock()
 	userAgent := c.config.UserAgents[rand.Intn(len(c.config.UserAgents))]
+	c.mu.Unlock()
 	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := c.httpClient.Do(req)
@@ -86,15 +105,13 @@ func (c *Crawler) request(urlStr string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	// Read the response body
-	buf := make([]byte, 1024*1024) // 1MB buffer
+	buf := make([]byte, 1024*1024)
 	n, _ := resp.Body.Read(buf)
 	return string(buf[:n]), nil
 }
 
 // normalizeLink converts relative URLs to absolute URLs
 func (c *Crawler) normalizeLink(link, rootURL string) string {
-	// Handle URLs that start with //
 	if strings.HasPrefix(link, "//") {
 		parsedRoot, err := url.Parse(rootURL)
 		if err != nil {
@@ -103,18 +120,15 @@ func (c *Crawler) normalizeLink(link, rootURL string) string {
 		return parsedRoot.Scheme + ":" + link
 	}
 
-	// Parse the URL
 	parsedURL, err := url.Parse(link)
 	if err != nil {
 		return ""
 	}
 
-	// If it's already an absolute URL, return it
 	if parsedURL.Scheme != "" {
 		return link
 	}
 
-	// Join the root URL with the relative URL
 	base, err := url.Parse(rootURL)
 	if err != nil {
 		return ""
@@ -125,19 +139,20 @@ func (c *Crawler) normalizeLink(link, rootURL string) string {
 
 // isValidURL checks if a URL is valid
 func (c *Crawler) isValidURL(urlStr string) bool {
-	// Regular expression for validating URLs
 	regex := regexp.MustCompile(
-		`(?i)^(?:http|https)s?://` + // http:// or https:// (case insensitive with (?i))
-			`(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|` + // domain
-			`localhost|` + // localhost
-			`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})` + // or IP
-			`(?:\d+)?` + // optional port
-			`(?:/?|[/?]\S+)$`) // path
+		`(?i)^(?:http|https)s?://` +
+			`(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|` +
+			`localhost|` +
+			`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})` +
+			`(?:\d+)?` +
+			`(?:/?|[/?]\S+)$`)
 	return regex.MatchString(urlStr)
 }
 
 // isBlacklisted checks if a URL is blacklisted
 func (c *Crawler) isBlacklisted(urlStr string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for _, blacklisted := range c.config.BlacklistedURLs {
 		if strings.Contains(urlStr, blacklisted) {
 			return true
@@ -153,7 +168,6 @@ func (c *Crawler) shouldAcceptURL(urlStr string) bool {
 
 // extractURLs extracts URLs from an HTML body
 func (c *Crawler) extractURLs(body, rootURL string) []string {
-	// Extract href attributes
 	pattern := `href=["'](.*?)["']`
 	regex := regexp.MustCompile(pattern)
 	matches := regex.FindAllStringSubmatch(body, -1)
@@ -161,15 +175,12 @@ func (c *Crawler) extractURLs(body, rootURL string) []string {
 	var urls []string
 	for _, match := range matches {
 		if len(match) > 1 {
-			// Ignore fragment links (links starting with #)
 			if strings.HasPrefix(match[1], "#") {
 				continue
 			}
 
-			// Normalize the link
 			normalizedURL := c.normalizeLink(match[1], rootURL)
 
-			// Check if the URL should be accepted
 			if c.shouldAcceptURL(normalizedURL) {
 				urls = append(urls, normalizedURL)
 			}
@@ -181,10 +192,10 @@ func (c *Crawler) extractURLs(body, rootURL string) []string {
 
 // removeAndBlacklist removes a link from the links list and adds it to the blacklist
 func (c *Crawler) removeAndBlacklist(link string) {
-	// Add to blacklist
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.config.BlacklistedURLs = append(c.config.BlacklistedURLs, link)
 
-	// Remove from links
 	for i, l := range c.links {
 		if l == link {
 			c.links = append(c.links[:i], c.links[i+1:]...)
@@ -193,70 +204,73 @@ func (c *Crawler) removeAndBlacklist(link string) {
 	}
 }
 
-// browseFromLinks browses from the available links recursively
-func (c *Crawler) browseFromLinks(depth int) {
-	// Check if we've reached the maximum depth
-	if depth >= c.config.MaxDepth {
-		log.Println("Maximum depth reached, moving to next root URL")
-		return
+// browseFromLinks browses from the available links iteratively.
+func (c *Crawler) browseFromLinks(ctx context.Context, depth int) {
+	for depth < c.config.MaxDepth {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		if c.isTimeoutReached() {
+			log.Println("Timeout has been reached, exiting")
+			return
+		}
+
+		c.mu.Lock()
+		if len(c.links) == 0 {
+			c.mu.Unlock()
+			log.Println("No links to browse, moving to next root URL")
+			return
+		}
+
+		randomIndex := rand.Intn(len(c.links))
+		randomLink := c.links[randomIndex]
+		c.mu.Unlock()
+
+		log.Printf("Visiting %s (depth: %d)", randomLink, depth)
+
+		body, err := c.request(ctx, randomLink)
+		if err != nil {
+			log.Printf("Error visiting %s: %v", randomLink, err)
+			c.removeAndBlacklist(randomLink)
+			continue
+		}
+
+		subLinks := c.extractURLs(body, randomLink)
+		log.Printf("Found %d links from %s", len(subLinks), randomLink)
+
+		c.mu.Lock()
+		sleepTime := time.Duration(rand.Intn(c.config.MaxSleep-c.config.MinSleep+1)+c.config.MinSleep) * time.Second
+		c.mu.Unlock()
+		log.Printf("Sleeping for %v", sleepTime)
+
+		select {
+		case <-time.After(sleepTime):
+		case <-ctx.Done():
+			return
+		}
+
+		c.mu.Lock()
+		if len(subLinks) > 1 {
+			c.links = subLinks
+		} else {
+			c.removeAndBlacklist(randomLink)
+		}
+		c.mu.Unlock()
+
+		depth++
 	}
-
-	// Check if we have any links to browse
-	if len(c.links) == 0 {
-		log.Println("No links to browse, moving to next root URL")
-		return
-	}
-
-	// Check if timeout has been reached
-	if c.isTimeoutReached() {
-		log.Println("Timeout has been reached, exiting")
-		return
-	}
-
-	// Select a random link
-	randomIndex := rand.Intn(len(c.links))
-	randomLink := c.links[randomIndex]
-
-	log.Printf("Visiting %s (depth: %d)", randomLink, depth)
-
-	// Visit the link
-	body, err := c.request(randomLink)
-	if err != nil {
-		log.Printf("Error visiting %s: %v", randomLink, err)
-		c.removeAndBlacklist(randomLink)
-		c.browseFromLinks(depth)
-		return
-	}
-
-	// Extract links from the page
-	subLinks := c.extractURLs(body, randomLink)
-	log.Printf("Found %d links from %s", len(subLinks), randomLink)
-
-	// Sleep for a random amount of time
-	sleepTime := time.Duration(rand.Intn(c.config.MaxSleep-c.config.MinSleep+1)+c.config.MinSleep) * time.Second
-	log.Printf("Sleeping for %v", sleepTime)
-	time.Sleep(sleepTime)
-
-	// If we found more than one link, update our links list
-	if len(subLinks) > 1 {
-		c.links = subLinks
-	} else {
-		// Otherwise, remove the current link from our list
-		c.removeAndBlacklist(randomLink)
-	}
-
-	// Continue browsing
-	c.browseFromLinks(depth + 1)
+	log.Println("Maximum depth reached, moving to next root URL")
 }
 
 // isTimeoutReached checks if the timeout has been reached
 func (c *Crawler) isTimeoutReached() bool {
-	// If timeout is 0, it means no timeout
 	if c.config.Timeout == 0 {
 		return false
 	}
 
-	// Check if the current time exceeds the start time plus the timeout
 	timeoutDuration := time.Duration(c.config.Timeout) * time.Second
 	return time.Since(c.startTime) > timeoutDuration
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
-	"os"
 	"os/signal"
 	"syscall"
 
@@ -12,7 +12,6 @@ import (
 )
 
 func main() {
-	// Parse command line arguments
 	var configFile string
 	var logLevel string
 	var timeout int
@@ -22,49 +21,35 @@ func main() {
 	flag.IntVar(&timeout, "timeout", 0, "for how long the crawler should be running, in seconds (0 means no timeout)")
 	flag.Parse()
 
-	// Set up logging
 	setLogLevel(logLevel)
 
-	// Load configuration
 	var cfg *config.Config
 	var err error
 
 	if configFile == "" {
-		// Use default configuration if no config file is specified
 		log.Println("No config file specified, using default configuration")
 		cfg, err = config.LoadDefaultConfig()
 		if err != nil {
 			log.Fatalf("Failed to load default config: %v", err)
 		}
 	} else {
-		// Load configuration from file
 		cfg, err = config.LoadFromFile(configFile)
 		if err != nil {
 			log.Fatalf("Failed to load config: %v", err)
 		}
 	}
 
-	// Set timeout if provided
 	if timeout > 0 {
 		cfg.Timeout = timeout
 	}
 
-	// Create and start crawler
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	c := crawler.NewCrawler(cfg)
 
-	// Handle graceful shutdown
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		<-sigChan
-		log.Println("Received shutdown signal, exiting gracefully...")
-		os.Exit(0)
-	}()
-
-	// Start crawling
 	log.Println("Starting urusai - HTTP/DNS traffic noise generator")
-	c.Crawl()
+	c.Crawl(ctx)
 }
 
 func setLogLevel(level string) {


### PR DESCRIPTION
## Summary

Fixes #10 — Urusai generates traffic noise one request at a time. This adds configurable concurrency (default: 3 workers) to multiply noise output.

### Changes

- **Config**: `Concurrency` field with JSON tag, validated in `Validate()` (defaults to 1 if ≤0)
- **Crawl() refactored**: Spawns N worker goroutines via `sync.WaitGroup`
- **Shared state protection**: `sync.Mutex` guards links, blacklist, UA selection
- **Context support**: `signal.NotifyContext` for graceful shutdown (also addresses #8)
- **Iterative browseFromLinks**: Converted from recursive (also addresses #7)
- **Interruptible sleep**: `select` with `time.After` and `ctx.Done()`

### Dependencies

This PR includes context support (#8) and iterative crawl (#7) inline since they are prerequisites for safe concurrent operation.

## Test plan

- [x] `TestValidateConcurrency` — zero→1, negative→1, positive preserved
- [x] `TestValidateTimeout` — negative→0
- [x] `go vet ./...` passes
- [x] `go test ./...` passes