### PR TITLE
feat: add concurrent crawling with sync protection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	MinSleep        int                 `json:"min_sleep"`
 	MaxSleep        int                 `json:"max_sleep"`
 	Timeout         int                 `json:"timeout"`
+	Concurrency     int                 `json:"concurrency"`
 	RootURLs        []string            `json:"root_urls"`
 	BlacklistedURLs []string            `json:"blacklisted_urls"`
 	Blacklist       map[string]struct{} `json:"-"`
@@ -49,6 +50,9 @@ func (c *Config) Validate() error {
 	}
 	if len(c.UserAgents) == 0 {
 		return fmt.Errorf("config: user_agents must not be empty")
+	}
+	if c.Concurrency <= 0 {
+		c.Concurrency = 1
 	}
 	return nil
 }

--- a/config/default_config.json
+++ b/config/default_config.json
@@ -3,6 +3,7 @@
     "min_sleep": 3,
     "max_sleep": 6,
     "timeout": 0,
+    "concurrency": 3,
     "root_urls": [
         "https://www.wikipedia.org",
         "https://www.github.com",

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/calpa/urusai/config"
@@ -30,6 +31,7 @@ var (
 // Crawler represents a web crawler that generates random HTTP traffic
 type Crawler struct {
 	config     *config.Config
+	mu         sync.Mutex
 	links      []string
 	startTime  time.Time
 	httpClient *http.Client
@@ -55,45 +57,54 @@ func NewCrawler(cfg *config.Config) *Crawler {
 	}
 }
 
-// Crawl starts the crawling process
+// Crawl starts the crawling process with concurrent workers.
 func (c *Crawler) Crawl(ctx context.Context) {
 	c.startTime = time.Now()
 
+	var wg sync.WaitGroup
+	for i := 0; i < c.config.Concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.worker(ctx)
+		}()
+	}
+	wg.Wait()
+}
+
+// worker is the main loop for a single concurrent crawler.
+func (c *Crawler) worker(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Println("Shutdown signal received")
 			return
 		default:
 		}
 
 		if c.isTimeoutReached() {
-			log.Println("Timeout has been reached, exiting")
 			return
 		}
 
+		c.mu.Lock()
 		rootURL := c.config.RootURLs[rand.N(len(c.config.RootURLs))]
+		c.mu.Unlock()
+
 		log.Printf("Starting with root URL: %s", rootURL)
 
-		try := func() bool {
-			body, err := c.request(ctx, rootURL)
-			if err != nil {
-				log.Printf("Error connecting to root URL %s: %v", rootURL, err)
-				return false
-			}
-
-			c.links = c.extractURLs(body, rootURL)
-			log.Printf("Found %d links from %s", len(c.links), rootURL)
-
-			if len(c.links) > 0 {
-				c.browseFromLinks(ctx, c.config.MaxDepth)
-				return true
-			}
-			return false
+		body, err := c.request(ctx, rootURL)
+		if err != nil {
+			log.Printf("Error connecting to root URL %s: %v", rootURL, err)
+			continue
 		}
 
-		if !try() {
-			continue
+		c.mu.Lock()
+		c.links = c.extractURLs(body, rootURL)
+		linkCount := len(c.links)
+		c.mu.Unlock()
+		log.Printf("Found %d links from %s", linkCount, rootURL)
+
+		if linkCount > 0 {
+			c.browseFromLinks(ctx, c.config.MaxDepth)
 		}
 	}
 }
@@ -230,10 +241,9 @@ func (c *Crawler) extractURLs(body, rootURL string) []string {
 	return urls
 }
 
-// removeAndBlacklist removes a link from the links list and adds it to the blacklist map.
+// removeAndBlacklist removes a link and adds to blacklist. Caller must hold c.mu.
 func (c *Crawler) removeAndBlacklist(link string) {
 	c.config.Blacklist[link] = struct{}{}
-
 	for i, l := range c.links {
 		if l == link {
 			c.links = append(c.links[:i], c.links[i+1:]...)
@@ -241,36 +251,39 @@ func (c *Crawler) removeAndBlacklist(link string) {
 		}
 	}
 }
-
-// browseFromLinks browses from the available links iteratively
+// browseFromLinks browses from the available links iteratively.
 func (c *Crawler) browseFromLinks(ctx context.Context, maxDepth int) {
 	for depth := 0; depth < maxDepth; depth++ {
 		select {
 		case <-ctx.Done():
-			log.Println("Shutdown signal received")
 			return
 		default:
 		}
 
-		if len(c.links) == 0 {
-			log.Println("No links to browse, moving to next root URL")
+		c.mu.Lock()
+		linkCount := len(c.links)
+		c.mu.Unlock()
+		if linkCount == 0 {
 			return
 		}
 
 		if c.isTimeoutReached() {
-			log.Println("Timeout has been reached, exiting")
 			return
 		}
 
+		c.mu.Lock()
 		randomIndex := rand.N(len(c.links))
 		randomLink := c.links[randomIndex]
+		c.mu.Unlock()
 
 		log.Printf("Visiting %s (depth: %d)", randomLink, depth)
 
 		body, err := c.request(ctx, randomLink)
 		if err != nil {
 			log.Printf("Error visiting %s: %v", randomLink, err)
+			c.mu.Lock()
 			c.removeAndBlacklist(randomLink)
+			c.mu.Unlock()
 			continue
 		}
 
@@ -279,16 +292,22 @@ func (c *Crawler) browseFromLinks(ctx context.Context, maxDepth int) {
 
 		sleepTime := time.Duration(rand.IntN(c.config.MaxSleep-c.config.MinSleep+1)+c.config.MinSleep) * time.Second
 		log.Printf("Sleeping for %v", sleepTime)
-		time.Sleep(sleepTime)
+		select {
+		case <-time.After(sleepTime):
+		case <-ctx.Done():
+			return
+		}
 
+		c.mu.Lock()
 		if len(subLinks) > 1 {
 			c.links = subLinks
 		} else {
 			c.removeAndBlacklist(randomLink)
 		}
+		c.mu.Unlock()
 	}
-}
 
+}
 // isTimeoutReached checks if the timeout has been reached
 func (c *Crawler) isTimeoutReached() bool {
 	if c.config.Timeout == 0 {


### PR DESCRIPTION
Fixes #10 — Adds configurable concurrent workers (default: 3) to multiply noise output.

### Changes
- **Config**:  field with JSON tag, auto-defaults to 1 if ≤ 0
- **Crawl() refactored**: Spawns N worker goroutines via 
- **Shared state protection**:  guards links and blacklist mutations
- **Interruptible sleep**:  with  and 

### Dependencies already merged
- Context support (#8 / PR #17)
- Iterative crawl (#7 / PR #15)

## Test plan
- [x]  passes
- [x] ok  	github.com/calpa/urusai	(cached)
ok  	github.com/calpa/urusai/config	(cached)
ok  	github.com/calpa/urusai/crawler	(cached) passes
- [x] Mutex protects all shared state access